### PR TITLE
fix: address init

### DIFF
--- a/custom_components/sunlogin/config_flow.py
+++ b/custom_components/sunlogin/config_flow.py
@@ -395,7 +395,7 @@ class SunLoginConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # if self._async_current_entries():
         #     return self.async_abort(reason="already_configured")
         unique_id = self.sunlogin.userid if self.sunlogin.userid is not None else user_input.get(CONF_USERNAME)
-        await self.async_set_unique_id(unique_id)
+        await self.async_set_unique_id(str(unique_id))
 
         devices = device_filter(self.sunlogin.device_list)
         

--- a/custom_components/sunlogin/sunlogin.py
+++ b/custom_components/sunlogin/sunlogin.py
@@ -904,12 +904,12 @@ class SunloginPlug(SunLoginDevice, ABC):
     @property
     def remote_address(self):
         remote_address = self.config.get(CONF_DEVICE_ADDRESS)
-        if remote_address is None:
-            return None
         if PLUG_API_VERSION == 1:
             return remote_address
-        elif PLUG_API_VERSION == 2 :
+        elif PLUG_API_VERSION == 2:
             return PLUG_URL
+        if remote_address is None:
+            return None
     
     @property
     def local_address(self):

--- a/custom_components/sunlogin/sunlogin.py
+++ b/custom_components/sunlogin/sunlogin.py
@@ -550,7 +550,7 @@ def plug_electric_process(data):
         power = power / 1000
         status[DP_POWER] = power
 
-    if (sub_electric := data.get('sub')) is not None:
+    if (sub_electric := data.get('sub')) is not None and not isinstance(sub_electric, int):
         for index, electric in enumerate(sub_electric):
             sub_current = electric['cur']
             sub_current = sub_current // 1000

--- a/custom_components/sunlogin/sunlogin_api.py
+++ b/custom_components/sunlogin/sunlogin_api.py
@@ -408,7 +408,7 @@ class PlugAPI_V2(HTTPRequest):
     
     def __init__(self, hass, address):
         self.hass = hass
-        self.address = address
+        self._address = address
         # self._address = HTTPS_SUFFIX + '47.111.169.221' + PLUG_PATH
         self.session = requests.Session()
 
@@ -516,7 +516,7 @@ class PlugAPI_V2_FAST(HTTPRequest):
 
     def __init__(self, hass, address):
         self.hass = hass
-        self.address = address
+        self._address = address
         # self._address = HTTPS_SUFFIX + '47.111.169.221' + PLUG_PATH
         self.adapters = dict()
         self.session = requests.Session()


### PR DESCRIPTION
Fix `address` initialization for both API_V2 and API_V2_FAST.
This PR solves #5 and #6.

P.S. It seems that P1Pro V3 does not support LAN control as there is no open ports.